### PR TITLE
[ISSUE-3] Leave Request APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,20 @@ response, err := c.GetEmployee(context.TODO(), "90a34ef1-50e4-4930-a9d6-xxxx", "
 employee := response.Data
 ```
 
+## List Leave Requests
+
+```go
+response, err := c.ListLeaveRequests(context.TODO(), "90a34ef1-50e4-4930-a9d6-xxxx", ListParams{})
+leaveRequests := response.Data.Items
+```
+
+## Get Leave Request details
+
+```go
+response, err := c.GetLeaveRequest(context.TODO(), "90a34ef1-50e4-4930-a9d6-xxxx", "90a34ef1-50e4-4930-a9d6-yyyy")
+leaveRequest := response.Data
+```
+
 ## How to Contribute
 
 - Create an issue to describe what you want to do

--- a/leave_request.go
+++ b/leave_request.go
@@ -1,0 +1,52 @@
+package employmenthero
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+
+type LeaveRequestListData struct {
+	Items []LeaveRequest `json:"items"`
+	ListResponse
+}
+
+type LeaveRequestListResponse struct {
+	Data LeaveRequestListData `json:"data"`
+}
+
+func (c *Client) ListLeaveRequests(ctx context.Context, oid string, ep ListParams) (*LeaveRequestListResponse, error) {
+	req, err := c.NewRequest(ctx, http.MethodGet, fmt.Sprintf("%s/api/v1/organisations/%s/leave_requests", c.APIBase, oid), nil)
+
+	if err != nil {
+		return nil, err
+	}
+
+	q := req.URL.Query()
+	q.Add("page_index", ep.PageIndex)
+	q.Add("item_per_page", ep.ItemPerPage)
+	req.URL.RawQuery = q.Encode()
+	response := &LeaveRequestListResponse{}
+
+	err = c.SendWithAuth(req, response)
+	return response, err
+}
+
+type LeaveRequestResponse struct {
+	Data LeaveRequest `json:"data"`
+}
+
+func (c *Client) GetLeaveRequest(ctx context.Context, oid string, lid string) (*LeaveRequestResponse, error) {
+	req, err := c.NewRequest(ctx, http.MethodGet, fmt.Sprintf("%s/api/v1/organisations/%s/leave_requests/%s", c.APIBase, oid, lid), nil)
+
+	if err != nil {
+		return nil, err
+	}
+
+	response := &LeaveRequestResponse{}
+
+	err = c.SendWithAuth(req, response)
+	return response, err
+}
+

--- a/leave_request_test.go
+++ b/leave_request_test.go
@@ -1,0 +1,58 @@
+package employmenthero
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/Thinkei/employmenthero-go/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	c, _ = NewClient(testClientID, testSecret, refreshToken, oauthBase, apiBase)
+	c.Client = &mocks.MockHttpClient{}
+}
+
+func TestListLeaveRequest(t *testing.T) {
+	r := ioutil.NopCloser(bytes.NewReader([]byte(`{"data":{"items":[{"id":"51c4b9c6-1ca5-4d72-8f75-6bb3a6xxxx","start_date":"2020-12-22T00:00:00+00:00","end_date":"2021-01-08T00:00:00+00:00","total_hours":83.6,"comment":"","status":"Declined","leave_balance_amount":0.0,"leave_category_name":"Annual Leave","reason":"test","employee_id":"xxxx-yyyyy"}],"item_per_page":20,"page_index":1,"total_pages":1,"total_items":1}}`)))
+
+	mocks.GetDoFunc = func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       r,
+		}, nil
+	}
+
+	response, err := c.ListLeaveRequests(context.TODO(), "organisation_uid", ListParams{})
+
+	assert.Equal(t, response.Data.ItemPerPage, 20)
+	assert.Equal(t, response.Data.PageIndex, 1)
+	assert.Equal(t, response.Data.TotalItems, 1)
+	assert.Equal(t, response.Data.TotalPages, 1)
+	expectedResult := []LeaveRequest{{Id: "51c4b9c6-1ca5-4d72-8f75-6bb3a6xxxx", StartDate: "2020-12-22T00:00:00+00:00", EndDate: "2021-01-08T00:00:00+00:00", TotalHours: 83.6, Status: "Declined", LeaveCategoryName: "Annual Leave", Reason: "test", EmployeeId: "xxxx-yyyyy"}}
+
+	assert.Equal(t, response.Data.Items, expectedResult)
+
+	assert.Nil(t, err)
+}
+
+func TestGetLeaveRequest(t *testing.T) {
+	r := ioutil.NopCloser(bytes.NewReader([]byte(`{"data":{"id":"51c4b9c6-1ca5-4d72-8f75-6bb3a6xxxx","start_date":"2020-12-22T00:00:00+00:00","end_date":"2021-01-08T00:00:00+00:00","total_hours":83.6,"comment":"","status":"Declined","leave_balance_amount":0.0,"leave_category_name":"Annual Leave","reason":"test","employee_id":"xxxx-yyyyy"}}`)))
+
+	mocks.GetDoFunc = func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       r,
+		}, nil
+	}
+
+	response, err := c.GetLeaveRequest(context.TODO(), "90a34ef1-50e4-4930-a9d6-xxxx", "90a34ef1-50e4-4930-a9d6-xxxx")
+
+	expectedResult := LeaveRequest{Id: "51c4b9c6-1ca5-4d72-8f75-6bb3a6xxxx", StartDate: "2020-12-22T00:00:00+00:00", EndDate: "2021-01-08T00:00:00+00:00", TotalHours: 83.6, Status: "Declined", LeaveCategoryName: "Annual Leave", Reason: "test", EmployeeId: "xxxx-yyyyy"}
+
+	assert.Equal(t, response.Data, expectedResult)
+	assert.Nil(t, err)
+}

--- a/types.go
+++ b/types.go
@@ -114,4 +114,17 @@ type (
 		SecondaryManager     BasicData   `json:"secondary_manager"`
 		ExternalId           string      `json:"external_id"`
 	}
+
+	LeaveRequest struct {
+		Id                 string  `json:"id"`
+		StartDate          string  `json:"start_date"`
+		EndDate            string  `json:"end_date"`
+		TotalHours         float32 `json:"total_hours"`
+		Comment            string  `json:"comment"`
+		Status             string  `json:"status"`
+		LeaveBalanceAmount float32 `json:"leave_balance_amount"`
+		LeaveCategoryName  string  `json:"leave_category_name"`
+		Reason             string  `json:"reason"`
+		EmployeeId         string  `json:"employee_id"`
+	}
 )


### PR DESCRIPTION
# Issue Link
fixed https://github.com/Thinkei/employmenthero-go/issues/3

# Describe

Regarding this API documentation https://developer.employmenthero.com/api-references/#get-leave-requests, we need to have two functions in this go package.

- [x] Get Leave Requests
- [x] Get A Leave Request
