### PR TITLE
[Feat] Add GetOAuth2Access to get the RefreshToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,26 @@ go get -u github.com/Thinkei/employmenthero-go
 import "github.com/Thinkei/employmenthero-go"
 
 // Create a client instance
-c, err := employmenthero.NewClient("clientID", "secretID", "refreshToken", "OAuthHost", "apiHost")
+c, err := employmenthero.NewClient("clientID", "secretID", "redirectUri", "OAuthHost", "apiHost")
 c.SetLog(os.Stdout) // Set log to terminal stdout
 
-accessToken, err := c.GetAccessToken(context.TODO())
+// Get Authorization code and then use it to get the EH OAuth2 Access tokens
+authroizationCode = "<authorizationCode>"
+responseToken, err := client.GetOAuth2Access(ctx, authorizationCode)
+
+// Save the refresh_token to anywhere you want,
+// but use it when you call other APIs to get our resources
+refreshToken := responseToken.RefreshToken
+c.SetRefreshToken(responseToken.RefreshToken)
+
+// call other APIs
+organisationsResp, err := client.ListOrganisations(ctx, employmenthero.ListParams{})
+
+if err != nil {
+	fmt.Printf("Get Organisation failed - %s", err)
+}
+
+fmt.Println(organisationsResp.Data.Items)
 ```
 
 ### List Organisations

--- a/bank_account_test.go
+++ b/bank_account_test.go
@@ -11,11 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func init() {
-	c, _ = NewClient(testClientID, testSecret, refreshToken, oauthBase, apiBase)
-	c.Client = &mocks.MockHttpClient{}
-}
-
 func TestListBankAccounts(t *testing.T) {
 	r := ioutil.NopCloser(bytes.NewReader([]byte(`{"data":{"items":[{"id": "883280d7-470c-42e0-83b2", "account_name":"peter","account_number":"000000000","bsb":"012345","amount":"0.0","primary_account":true}],"item_per_page":20,"page_index":1,"total_pages":1,"total_items":1}}`)))
 

--- a/certification_test.go
+++ b/certification_test.go
@@ -11,11 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func init() {
-	c, _ = NewClient(testClientID, testSecret, refreshToken, oauthBase, apiBase)
-	c.Client = &mocks.MockHttpClient{}
-}
-
 func TestListCerification(t *testing.T) {
 	r := ioutil.NopCloser(bytes.NewReader([]byte(`{"data":{"items":[{"id": "6538a2bb-2b34-4437-9a00-92af3dab5b59", "name": "Full-disk encryption", "type": "check" }],"item_per_page":20,"page_index":1,"total_pages":1,"total_items":1}}`)))
 

--- a/client_test.go
+++ b/client_test.go
@@ -13,25 +13,25 @@ import (
 
 var testClientID = "AXy9orp"
 var testSecret = "UgS2iCw"
-var refreshToken = "w+123jkvsk"
+var redirectURI = "https://test.com/callback"
 var oauthBase = "https://oauth.eh.com"
 var apiBase = "https://api.eh.com"
 
 var c *Client
 
 func init() {
-	c, _ = NewClient(testClientID, testSecret, refreshToken, oauthBase, apiBase)
+	c, _ = NewClient(testClientID, testSecret, redirectURI, oauthBase, apiBase)
 	c.Client = &mocks.MockHttpClient{}
 }
 
 func TestNewClient(t *testing.T) {
 	_, e := NewClient("", "", "", "", "")
 
-	assert.Equal(t, e.Error(), "Client ID, Secret and APIBase are required to create a Client")
+	assert.Equal(t, e.Error(), "Client ID, Secret, RedirectURI, OAuthBase and APIBase are required to create a Client")
 
 	assert.Equal(t, testClientID, c.ClientID)
 	assert.Equal(t, testSecret, c.Secret)
-	assert.Equal(t, refreshToken, c.Token.RefreshToken)
+	assert.Equal(t, redirectURI, c.RedirectURI)
 	assert.Equal(t, oauthBase, c.OAuthBase)
 	assert.Equal(t, apiBase, c.APIBase)
 }
@@ -44,6 +44,7 @@ func TestGetAccessTokenInvalidClientResponse(t *testing.T) {
 			Body: r,
 		}, nil
 	}
+	c.SetRefreshToken("refresh_token")
 	response, err := c.GetAccessToken(context.TODO())
 	assert.Empty(t, response.Token)
 	assert.NotNil(t, err)
@@ -60,7 +61,27 @@ func TestGetAccessTokenSuccess(t *testing.T) {
 			Body: r,
 		}, nil
 	}
+	c.SetRefreshToken("refresh_token")
 	response, err := c.GetAccessToken(context.TODO())
+	assert.Nil(t, err)
+	assert.Equal(t, response.RefreshToken, "xxYYzz")
+	assert.Equal(t, response.Token, "YYUUzz")
+	assert.Equal(t, response.Type, "bearer")
+	assert.Equal(t, response.ExpiresIn, 900)
+}
+
+func TestGetOAuth2Access(t *testing.T) {
+	json := `{"access_token":"YYUUzz","refresh_token":"xxYYzz","token_type":"bearer","expires_in":900}`
+	r := ioutil.NopCloser(bytes.NewReader([]byte(json)))
+
+	mocks.GetDoFunc = func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Body: r,
+		}, nil
+	}
+	c.SetRefreshToken("refresh_token")
+	response, err := c.GetOAuth2Access(context.TODO(), "AuthorizationCode")
 	assert.Nil(t, err)
 	assert.Equal(t, response.RefreshToken, "xxYYzz")
 	assert.Equal(t, response.Token, "YYUUzz")

--- a/emergency_contact_test.go
+++ b/emergency_contact_test.go
@@ -11,11 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func init() {
-	c, _ = NewClient(testClientID, testSecret, refreshToken, oauthBase, apiBase)
-	c.Client = &mocks.MockHttpClient{}
-}
-
 func TestListEmergencyContacts(t *testing.T) {
 	r := ioutil.NopCloser(bytes.NewReader([]byte(`{"data":{"items":[{ "id": 123, "contact_name": "Daniel Levi"}],"item_per_page":20,"page_index":1,"total_pages":1,"total_items":1}}`)))
 

--- a/employee_certification_test.go
+++ b/employee_certification_test.go
@@ -11,11 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func init() {
-	c, _ = NewClient(testClientID, testSecret, refreshToken, oauthBase, apiBase)
-	c.Client = &mocks.MockHttpClient{}
-}
-
 func TestListEmployeeCertification(t *testing.T) {
 	r := ioutil.NopCloser(bytes.NewReader([]byte(`{"data":{"items":[{"id": "3128a2bb-2b34-4437-9a00", "name": "Full-disk encryption", "certification_id": "6538a2bb-2b34-4437-9a00", "type": "Check", "expiry_date": "2021-01-04T00:00:00+00:00", "completion_date": "2020-01-04T00:00:00+00:00", "driver_problem": false, "driver_details": "", "status": "Outstanding", "reason": "" }],"item_per_page":20,"page_index":1,"total_pages":1,"total_items":1}}`)))
 

--- a/employee_test.go
+++ b/employee_test.go
@@ -11,11 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func init() {
-	c, _ = NewClient(testClientID, testSecret, refreshToken, oauthBase, apiBase)
-	c.Client = &mocks.MockHttpClient{}
-}
-
 func TestListEmployees(t *testing.T) {
 	r := ioutil.NopCloser(bytes.NewReader([]byte(`{"data":{"items":[{"id":"3cfd1633-4920-xxxy-be7e-98i13159x74", "account_email": "dev@employmenthero.com", "title": "dev", "role": "employee", "first_name":"Hoa", "last_name": "Nguyen", "Address": "Sydney, NSW"}],"item_per_page":20,"page_index":1,"total_pages":1,"total_items":1}}`)))
 

--- a/employment_history_test.go
+++ b/employment_history_test.go
@@ -11,11 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func init() {
-	c, _ = NewClient(testClientID, testSecret, refreshToken, oauthBase, apiBase)
-	c.Client = &mocks.MockHttpClient{}
-}
-
 func TestListEmploymentHistories(t *testing.T) {
 	r := ioutil.NopCloser(bytes.NewReader([]byte(`{"data":{"items":[{ "id": "0f551b48-c958-4359-87c2", "title": "Grad developer", "start_date":"2017-03-01T00:00:00+00:00", "end_date": null, "employment_type": "Part-time" }],"item_per_page":20,"page_index":1,"total_pages":1,"total_items":1}}`)))
 

--- a/leave_request_test.go
+++ b/leave_request_test.go
@@ -11,11 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func init() {
-	c, _ = NewClient(testClientID, testSecret, refreshToken, oauthBase, apiBase)
-	c.Client = &mocks.MockHttpClient{}
-}
-
 func TestListLeaveRequest(t *testing.T) {
 	r := ioutil.NopCloser(bytes.NewReader([]byte(`{"data":{"items":[{"id":"51c4b9c6-1ca5-4d72-8f75-6bb3a6xxxx","start_date":"2020-12-22T00:00:00+00:00","end_date":"2021-01-08T00:00:00+00:00","total_hours":83.6,"comment":"","status":"Declined","leave_balance_amount":0.0,"leave_category_name":"Annual Leave","reason":"test","employee_id":"xxxx-yyyyy"}],"item_per_page":20,"page_index":1,"total_pages":1,"total_items":1}}`)))
 

--- a/organisation_test.go
+++ b/organisation_test.go
@@ -11,11 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func init() {
-	c, _ = NewClient(testClientID, testSecret, refreshToken, oauthBase, apiBase)
-	c.Client = &mocks.MockHttpClient{}
-}
-
 func TestListOrganisation(t *testing.T) {
 	r := ioutil.NopCloser(bytes.NewReader([]byte(`{"data":{"items":[{"id":"3cfd1633-4920-xxxy-be7e-98i13159x74","name":"Employment Hero","phone":"+612803848123","country":"AU","logo_url":"https://logo.com"}],"item_per_page":20,"page_index":1,"total_pages":1,"total_items":1}}`)))
 

--- a/pay_detail_test.go
+++ b/pay_detail_test.go
@@ -11,11 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func init() {
-	c, _ = NewClient(testClientID, testSecret, refreshToken, oauthBase, apiBase)
-	c.Client = &mocks.MockHttpClient{}
-}
-
 func TestListPayDetails(t *testing.T) {
 	r := ioutil.NopCloser(bytes.NewReader([]byte(`{"data":{"items":[{"id": "7d9e663f-a493-4523-aea4-4f299efeexxx", "effective_from": "2020-04-21", "classification": "Day Working - Full Time", "industrial_instrument": "Wholesale Award 2010", "pay_rate_template": "Permanent Storeworker", "anniversary_date": "2020-07-25T00:00:00+00:00", "salary": 50, "salary_type": "Hour", "pay_unit": "Hourly", "pay_category": "Permanent Ordinary Hours", "leave_allowance_template": "Permanent Leave Allowance", "change_reason": "Some reason...", "comments": "Some comments..." }],"item_per_page":20,"page_index":1,"total_pages":1,"total_items":1}}`)))
 

--- a/payslip_test.go
+++ b/payslip_test.go
@@ -11,11 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func init() {
-	c, _ = NewClient(testClientID, testSecret, refreshToken, oauthBase, apiBase)
-	c.Client = &mocks.MockHttpClient{}
-}
-
 func TestListPayslips(t *testing.T) {
 	r := ioutil.NopCloser(bytes.NewReader([]byte(`{"data":{"items":[{"id": "e27387ba-2105-4d12-be95", "first_name": "Daniel", "last_name": "Nguyen", "total_deduction": null, "net_pay": 2520.15, "super": 301.15, "wages": 3346.15, "reimbursements": null, "tax": 826.0, "name": "Alex Kopczynski", "address_line1": "4 Sava", "address_line2": null, "suburb": "123 sydney", "postcode": "0880", "post_tax_deduction": 0.0, "pre_tax_deduction": 0.0, "base_rate": 87000.0, "hourly_rate": 0.0, "base_rate_unit": "Annually", "employment_type": "Annually", "payment_date": "2012-07-11T00:00:00+10:00"}],"item_per_page":20,"page_index":1,"total_pages":1,"total_items":1}}`)))
 

--- a/policy_test.go
+++ b/policy_test.go
@@ -11,11 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func init() {
-	c, _ = NewClient(testClientID, testSecret, refreshToken, oauthBase, apiBase)
-	c.Client = &mocks.MockHttpClient{}
-}
-
 func TestListPolicy(t *testing.T) {
 	r := ioutil.NopCloser(bytes.NewReader([]byte(`{"data":{"items":[{"id": "1d25a390-7b0e-0135-0209", "name": "Wonderful Company - Full-Disk Encryption Policy", "induction": true, "created_at": "2017-09-14T10:03:51+10:00"}],"item_per_page":20,"page_index":1,"total_pages":1,"total_items":1}}`)))
 

--- a/superannuation_detail_test.go
+++ b/superannuation_detail_test.go
@@ -11,11 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func init() {
-	c, _ = NewClient(testClientID, testSecret, refreshToken, oauthBase, apiBase)
-	c.Client = &mocks.MockHttpClient{}
-}
-
 func TestGetSuperannuationDetail(t *testing.T) {
 	r := ioutil.NopCloser(bytes.NewReader([]byte(`{"data":{"fund_name": "SUPER Super", "member_number": "184752", "product_code": "29400111", "employer_nominated_fund": true, "fund_abn": "19905421111", "electronic_service_address": "CLICKSUPER", "fund_email": "some_email@email.com", "account_name": "Daniel", "account_bsb": "HST011xxx", "account_number": "25767731xxx"}}`)))
 

--- a/tax_declaration_test.go
+++ b/tax_declaration_test.go
@@ -11,11 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func init() {
-	c, _ = NewClient(testClientID, testSecret, refreshToken, oauthBase, apiBase)
-	c.Client = &mocks.MockHttpClient{}
-}
-
 func TestGetTaxDeclaration(t *testing.T) {
 	r := ioutil.NopCloser(bytes.NewReader([]byte(`{"data":{"first_name":"www","last_name":"www","tax_file_number":"000000000","tax_au_resident":false,"tax_foreign_resident":true,"working_holiday_maker":false,"tax_free":false,"tax_help_debt":false,"tax_financial_supplement_debt":false}}`)))
 

--- a/team_test.go
+++ b/team_test.go
@@ -11,11 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func init() {
-	c, _ = NewClient(testClientID, testSecret, refreshToken, oauthBase, apiBase)
-	c.Client = &mocks.MockHttpClient{}
-}
-
 func TestListTeams(t *testing.T) {
 	r := ioutil.NopCloser(bytes.NewReader([]byte(`{"data":{"items":[{"id":"51c4b9c6-1ca5-4d72-8f75-6bb3a6xxxx", "name": "Developers", "status": "active"}],"item_per_page":20,"page_index":1,"total_pages":1,"total_items":1}}`)))
 

--- a/timesheet_entry_test.go
+++ b/timesheet_entry_test.go
@@ -11,11 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func init() {
-	c, _ = NewClient(testClientID, testSecret, refreshToken, oauthBase, apiBase)
-	c.Client = &mocks.MockHttpClient{}
-}
-
 func TestListTimesheetEntries(t *testing.T) {
 	r := ioutil.NopCloser(bytes.NewReader([]byte(`{"data":{"items":[{"id":"0f551b48-c958-4359-87c2","employee_id":"9e080b45-244f-4fbd-88d1","date":"2020-12-03T00:00:00+00:00","start_time":null,"end_time":null,"status":"approved","units":5.0,"reason":null,"comment":"h","time":18000,"cost_centre":{"id":"e9a4df80-5d05-444b-ab09","name":"Hoa's Bakery"}}],"item_per_page":20,"page_index":1,"total_pages":1,"total_items":1}}`)))
 


### PR DESCRIPTION
# Describe

Following the current implementation of EH OAuth2 authentication flow, EH is only supporting `authorization_code` flow, so it means this lib should have a way to archive the AccessToken and RefreshToken via the RedirectURI and the AuthorizationCode.